### PR TITLE
Changed version of tika jar to generic

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -6,7 +6,7 @@ require 'yaml'
 
 class Yomu
   GEMPATH = File.dirname(File.dirname(__FILE__))
-  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.3.jar')
+  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.*.jar')
 
   # Read text or metadata from a data buffer.
   #


### PR DESCRIPTION
I had the following error after yomu gem update 'Unable to access jarfile /gems/yomu-0.1.7/jar/tika-app-1.3.jar', there was only 'tika-app-1.4.jar' file in that folder.
