### PR TITLE
Update tika-app jar to fixed version

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -6,7 +6,7 @@ require 'yaml'
 
 class Yomu
   GEMPATH = File.dirname(File.dirname(__FILE__))
-  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.*.jar')
+  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.4.jar')
 
   # Read text or metadata from a data buffer.
   #


### PR DESCRIPTION
i believe that current version of the gem can be used only with JRE 7, so the version of tika-app jar should be 1.4.
Previous fix worked fine with os X and ubuntu, but it looks like it fails with windows. This change should fix it
