### PR TITLE
URI false positive. Yomu init, changing order

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -60,10 +60,10 @@ class Yomu
 
   def initialize(input)
     if input.is_a? String
-      if input =~ URI::regexp
-        @uri = URI.parse input
-      elsif File.exists? input
+      if File.exists? input
         @path = input
+      elsif input =~ URI::regexp
+        @uri = URI.parse input
       else
         raise Errno::ENOENT.new "missing file or invalid URI - #{input}"
       end


### PR DESCRIPTION
The URI::regexp is too agressive. on osx, if a file or path contains the "/"-character it will be enterpreted as ":", which triggers this to think it is a url, even though it should be a file.
