### PR TITLE
Fixing potential bug in html method

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -91,9 +91,9 @@ class Yomu
   #   yomu.html
 
   def html
-    return @text if defined? @text
+    return @html if defined? @html
 
-    @text = Yomu.read :html, data
+    @html = Yomu.read :html, data
   end
 
   # Returns the metadata hash of the Yomu document.


### PR DESCRIPTION
There is an overlap in the use of the `@text` variable. It is used to store both html and text reading.

I suspect this is a bug in the html method. Though I am unsure if the Tika :text and Tika :html actually returns different things, I would think that it possibly do so.
