### PR TITLE
Read files in binary mode for Windows compatibility

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -17,7 +17,7 @@ class Yomu
 
   # Read text or metadata from a data buffer.
   #
-  #   data = File.read 'sample.pages'
+  #   data = File.binread 'sample.pages'
   #   text = Yomu.read :text, data
   #   metadata = Yomu.read :metadata, data
 
@@ -58,7 +58,7 @@ class Yomu
 
   def self._server_read(_, data)
     s = TCPSocket.new('localhost', @@server_port)
-    file = StringIO.new(data, 'r')
+    file = StringIO.new(data, 'rb')
 
     while 1
       chunk = file.read(65536)
@@ -203,7 +203,7 @@ class Yomu
     return @data if defined? @data
 
     if path?
-      @data = File.read @path
+      @data = File.binread @path
     elsif uri?
       @data = Net::HTTP.get @uri
     elsif stream?

--- a/spec/yomu_spec.rb
+++ b/spec/yomu_spec.rb
@@ -2,7 +2,7 @@ require 'helper.rb'
 require 'yomu'
 
 describe Yomu do
-  let(:data) { File.read 'spec/samples/sample.docx' }
+  let(:data) { File.binread 'spec/samples/sample.docx' }
 
   before do
     ENV['JAVA_HOME'] = nil
@@ -22,7 +22,7 @@ describe Yomu do
     end
 
     it 'reads metadata values with colons as strings' do
-      data = File.read 'spec/samples/sample-metadata-values-with-colons.doc'
+      data = File.binread 'spec/samples/sample-metadata-values-with-colons.doc'
       metadata = Yomu.read :metadata, data
 
       expect( metadata['dc:title'] ).to eql 'problem: test'


### PR DESCRIPTION
Under Windows the default 'text' file mode performs some unwanted translations.