### PR TITLE
Updated to Tika 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+
+before_install:
+  - gem update bundler

--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -9,7 +9,7 @@ require 'stringio'
 
 class Yomu
   GEMPATH = File.dirname(File.dirname(__FILE__))
-  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.11.jar')
+  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.14.jar')
   DEFAULT_SERVER_PORT = 9293 # an arbitrary, but perfectly cromulent, port
 
   @@server_port = nil


### PR DESCRIPTION
I was getting some `NullPointerException` when reading some docx files using Tika 1.11.  Tika 1.14 appears to have fixed those.

Also modified travis config to update bundler because of known issue. See https://github.com/travis-ci/travis-ci/issues/5239