### PR TITLE
Remove explicit dependency on gems in stdlib

### DIFF
--- a/yomu.gemspec
+++ b/yomu.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'mime-types', '~> 1.23'
-  spec.add_runtime_dependency 'json', '~> 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
`json` is included in the Ruby standard library for all supported versions of Ruby.