### PR TITLE
Relax JSON version constraint for Ruby 2.4

### DIFF
--- a/yomu.gemspec
+++ b/yomu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'mime-types', '~> 1.23'
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json', '>= 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Due to changes in Ruby 2.4's C API, JSON 1.8.3. can not successfully be built for this Ruby version.

The common fix employed by other gems is to relax the version constraint as done here.