### PR TITLE
Better handling of Java path

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -262,7 +262,7 @@ class Yomu
   end
 
   def self.java
-    ENV['JAVA_HOME'] ? ENV['JAVA_HOME'] + '/bin/java' : 'java'
+    ENV['JAVA_HOME'].to_s.strip.length > 0 ? File.join(ENV['JAVA_HOME'], '/bin/java') : 'java'
   end
   private_class_method :java
 end


### PR DESCRIPTION
In my case, I had `JAVA_HOME` set to `""` for some reason, causing the error message talking about `/bin/java`. Checking like this, and using `File.join` should solve most of the similar issues.

The `.to_s` makes this code work with `nil` also, so `nil.to_s.length == 0` 👍